### PR TITLE
Fix(component/button): l'attributo type non può contenere una classe

### DIFF
--- a/docs/componenti/bottoni.md
+++ b/docs/componenti/bottoni.md
@@ -208,7 +208,7 @@ Per creare bottoni o gruppi di bottoni a tutta larghezza, come i _block buttons_
 {% capture example %}
 
 <div class="d-grid gap-2">
-  <button class="btn btn-primary" type="button btn-me">Primary</button>
+  <button class="btn btn-primary btn-me" type="button">Primary</button>
   <button class="btn btn-secondary" type="button">Secondary</button>
 </div>
 {% endcapture %}{% include example.html content=example %}

--- a/docs/componenti/bottoni.md
+++ b/docs/componenti/bottoni.md
@@ -201,7 +201,7 @@ Per ottenere bottoni di dimensione più grande o più piccola, è sufficiente ut
 <button type="button" class="btn btn-secondary btn-xs">Secondary Mini</button>
 {% endcapture %}{% include example.html content=example %}
 
-#### A tutta laghezza
+#### A tutta larghezza
 
 Per creare bottoni o gruppi di bottoni a tutta larghezza, come i _block buttons_ di Bootstrap 4, utilizzare un mix delle utilities **display** e **gap**. Con queste utilities abbiamo più controllo su spaziature, allineamento e comportamento responsive rispetto al classico _block button_.
 


### PR DESCRIPTION
Ho corretto un errore di sintassi, erroneamente è stata inserita la classe `btn-me` dentro l'attributo `type` e un errore di battitura

<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
