### PR TITLE
Fix: Icona hamburger light solo quando l'header centrale è light #35

### DIFF
--- a/src/scss/custom/_headernavbartheme.scss
+++ b/src/scss/custom/_headernavbartheme.scss
@@ -1,10 +1,10 @@
 @media (max-width: #{map-get($grid-breakpoints, lg)}) {
-  .it-header-navbar-wrapper {
-    &.theme-light-desk {
-      .custom-navbar-toggler .icon {
-        fill: $navigation-light-text-color;
-      }
+  .it-header-center-wrapper.theme-light + .it-header-navbar-wrapper {
+    .custom-navbar-toggler .icon {
+      fill: $navigation-light-text-color;
     }
+  }
+  .it-header-navbar-wrapper {
     &.theme-dark-mobile {
       .navbar {
         // navbar mobile


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
Ho modificato l'assegnazione del colore `$navigation-light-text-color` solo quando l'header centrale ha la classe `theme-light`

rif #35 

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
