### PR TITLE
z-index di it-nav-wrapper rompe le modal

### DIFF
--- a/src/scss/custom/_header.scss
+++ b/src/scss/custom/_header.scss
@@ -4,7 +4,7 @@
 .it-header-wrapper {
   .it-nav-wrapper {
     position: relative;
-    z-index: 2;
+    z-index: auto;
     // se ha un menu
     .it-brand-wrapper {
       padding-left: $v-gap * 4;
@@ -13,6 +13,7 @@
       transition: padding-top 0.3s ease;
 
       position: absolute;
+      z-index: 2;
       left: 0;
       top: 50%;
       margin-top: -$header-nav-button-distance;


### PR DESCRIPTION
Il fix #50 che risolve l'issue #49 rompe il funzionamento delle modal quando la navbar non è sticky. Riprendendo l'idea di @OscarBresolin ho impostato `z-index: 2` a `it-header-navbar-wrapper` invece che a `it-nav-wrapper` e tutto funziona correttamente.

Senza fix proposto
![issue](https://user-images.githubusercontent.com/4628942/174347218-05f102fd-8f0f-4d79-98cb-bbc0c2926cab.gif)

Con il fix proposto
![fix](https://user-images.githubusercontent.com/4628942/174347297-fafc0055-7dc0-4993-ad7c-48e57cad7cd8.gif)


<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione

<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist

<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->

- [ ] Le modifiche sono conformi alle [linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/5.1/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://docs.italia.it/italia/designers-italia/design-linee-guida-docs/it/stabile/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C7VPAUVB3)! -->
